### PR TITLE
beeper: disable creating desktop file and icon

### DIFF
--- a/pkgs/beeper/default.nix
+++ b/pkgs/beeper/default.nix
@@ -36,12 +36,10 @@ appimageTools.wrapAppImage {
 
   extraInstallCommands = ''
     mkdir -p $out/share/beeper
-    cp -a ${appimageContents}/locales $out/share/beeper
-    cp -a ${appimageContents}/resources $out/share/beeper
     cp -a ${appimageContents}/usr/share/icons $out/share/
     install -Dm 644 ${appimageContents}/beepertexts.desktop -t $out/share/applications/
 
-    substituteInPlace $out/share/applications/beepertexts.desktop --replace "AppRun" "beeper"
+    substituteInPlace $out/share/applications/beepertexts.desktop --replace-fail "AppRun" "beeper"
 
     . ${makeWrapper}/nix-support/setup-hook
     wrapProgram $out/bin/beeper \
@@ -66,7 +64,7 @@ appimageTools.wrapAppImage {
     });
   };
 
-  meta = with lib; {
+  meta ={
     description = "Universal chat app";
     longDescription = ''
       Beeper is a universal chat app. With Beeper, you can send
@@ -74,7 +72,7 @@ appimageTools.wrapAppImage {
       many different chat networks.
     '';
     homepage = "https://beeper.com";
-    license = licenses.unfree;
+    license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     mainProgram = "beeper";
     platforms = [ "x86_64-linux" ];

--- a/pkgs/beeper/default.nix
+++ b/pkgs/beeper/default.nix
@@ -18,6 +18,12 @@ let
 
   appimageContents = appimageTools.extract {
     inherit pname version src;
+
+    postExtract = ''
+      # disable creating a desktop file and icon in the home folder during runtime
+      linuxConfigFilename=$out/resources/app/build/main/linux-*.mjs
+      echo "export function registerLinuxConfig() {}" > $linuxConfigFilename
+    '';
   };
 in
 


### PR DESCRIPTION
After this, `~/.local/share/applications/beepertexts.desktop` is no longer created and there are no permission denied errors due to beeper trying to create icons at runtime.